### PR TITLE
Support ad config in article page

### DIFF
--- a/packages/article/src/ad-targeting-config.js
+++ b/packages/article/src/ad-targeting-config.js
@@ -1,0 +1,101 @@
+export interface PlatformAdConfig {
+  adUnit: string;
+  networkId: string;
+  testMode: string;
+  sectionId: string;
+  sectionName: string;
+  articlePositionInSlot: number;
+  appVersion: string;
+  operatingSystem: string;
+  operatingSystemVersion: string;
+  cookieEid: string;
+  cookieAcsTnl: string;
+  cookieIamTgt: string;
+  deviceId: string;
+  deviceIdHash: string;
+  environment: string;
+  isLoggedIn: boolean;
+  platform: "mobile" | "tablet";
+}
+
+export interface ArticleAdConfig {
+  id: string;
+  headline: string;
+}
+
+export interface AdTargetingConfig {
+  // Device + Article
+  Timeline: string;
+  edition: "tnl-english";
+  Shared: "0";
+  testmode: string;
+  sec_id: string;
+  cont_type: "art";
+  av: string;
+  ft: "";
+  kw: string;
+  st: "Member";
+  aid: string;
+  cos: string;
+  cov: string;
+  cpn: string;
+  did: string;
+  eid: string;
+  env: string;
+  log: string;
+  pid: string;
+  pos: "article_ad";
+  vid: string;
+  cips: string;
+  "did#": string;
+  path: string;
+  slot: number;
+  pform: string;
+  share_token: "";
+  Timeline_Id: string;
+  iam_tgt: string;
+  section: string;
+  excl_cat: "";
+}
+
+export const adTargetConfig = (
+  platformAdConfig: PlatformAdConfig,
+  articleAdConfig: ArticleAdConfig
+): AdTargetingConfig => ({
+  networkId: platformAdConfig.adUnit,
+  adUnit: platformAdConfig.networkId,
+  pageTargeting: {
+    Timeline: "0",
+    edition: "tnl-english",
+    Shared: "0",
+    testmode: platformAdConfig.testMode,
+    sec_id: platformAdConfig.sectionId,
+    cont_type: "art",
+    av: platformAdConfig.appVersion,
+    ft: "",
+    kw: articleAdConfig.headline.toLowerCase().replace(/\s+/g, ","),
+    st: "Member",
+    aid: articleAdConfig.id,
+    cos: platformAdConfig.operatingSystem,
+    cov: platformAdConfig.operatingSystemVersion,
+    cpn: platformAdConfig.cookieEid,
+    did: platformAdConfig.deviceId,
+    eid: platformAdConfig.cookieEid,
+    env: platformAdConfig.environment,
+    log: platformAdConfig.isLoggedIn ? "1" : "0",
+    pid: platformAdConfig.cookieEid,
+    pos: "article_ad",
+    vid: "",
+    cips: platformAdConfig.cookieAcsTnl,
+    "did#": platformAdConfig.deviceIdHash,
+    path: platformAdConfig.sectionName,
+    slot: platformAdConfig.articlePositionInSlot,
+    pform: platformAdConfig.platform,
+    share_token: "",
+    Timeline_Id: platformAdConfig.sectionName,
+    iam_tgt: platformAdConfig.cookieIamTgt,
+    section: platformAdConfig.sectionName,
+    excl_cat: ""
+  },
+  slotTargeting: {}
+});

--- a/packages/article/src/ad-targeting-config.js
+++ b/packages/article/src/ad-targeting-config.js
@@ -24,7 +24,6 @@ export interface ArticleAdConfig {
 }
 
 export interface AdTargetingConfig {
-  // Device + Article
   Timeline: string;
   edition: "tnl-english";
   Shared: "0";

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -4,30 +4,40 @@ import React from "react";
 import { ArticleProvider } from "@times-components/provider";
 import withClient from "@thetimes/with-client";
 import Article from "@times-components/article";
+import { PlatformAdConfig, adTargetConfig } from "./ad-targeting-config";
 
 type ArticleProps = {
   articleId: string,
   analyticsStream: (data: any) => void,
-  onRelatedArticlePress: (extras: any) => void
+  onRelatedArticlePress: (extras: any) => void,
+  platformAdConfig: PlatformAdConfig
 };
 
 const ArticleDetailsPage = ({
   articleId,
   analyticsStream,
-  onRelatedArticlePress
+  onRelatedArticlePress,
+  platformAdConfig
 }: ArticleProps) => (
   <ArticleProvider id={articleId} debounceTimeMs={100}>
-    {({ article, isLoading, error }) => (
-      <Article
-        article={article}
-        isLoading={isLoading}
-        error={error}
-        analyticsStream={analyticsStream}
-        onRelatedArticlePress={(events, extras) =>
-          onRelatedArticlePress(extras)
-        }
-      />
-    )}
+    {({ article, isLoading, error }) => {
+      const adConfig = isLoading
+        ? {}
+        : adTargetConfig(platformAdConfig, article);
+
+      return (
+        <Article
+          article={article}
+          isLoading={isLoading}
+          error={error}
+          analyticsStream={analyticsStream}
+          adConfig={adConfig}
+          onRelatedArticlePress={(events, extras) =>
+            onRelatedArticlePress(extras)
+          }
+        />
+      );
+    }}
   </ArticleProvider>
 );
 


### PR DESCRIPTION
This PR adds the support for native parameters for ads, this is done through a `platformConfig` parameter in the article component.

![image](https://user-images.githubusercontent.com/1263058/37595243-ff9362ee-2b6f-11e8-8082-13bf165588b1.png)
