### PR TITLE
Bump article dependency version

### DIFF
--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@thetimes/with-client": "1.0.7",
     "@times-components/article": "0.62.13",
-    "@times-components/provider": "0.26.0",
+    "@times-components/provider": "0.26.4",
     "react": "16.2.0",
     "react-native": "0.53.3"
   },

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@thetimes/with-client": "1.0.7",
-    "@times-components/article": "0.62.2",
+    "@times-components/article": "0.62.13",
     "@times-components/provider": "0.26.0",
     "react": "16.2.0",
     "react-native": "0.53.3"

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@thetimes/with-client": "1.0.7",
     "@times-components/author-profile": "0.54.1",
-    "@times-components/provider": "0.26.0",
+    "@times-components/provider": "0.26.4",
     "react": "16.2.0",
     "react-native": "0.53.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,46 @@
 # yarn lockfile v1
 
 
+"@storybook/addon-actions@3.3.15":
+  version "3.3.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.3.15.tgz#2831e52947dc258208dd17804b479f7acc62d859"
+  dependencies:
+    deep-equal "^1.0.1"
+    global "^4.3.2"
+    make-error "^1.3.2"
+    prop-types "^15.6.0"
+    react-inspector "^2.2.2"
+    uuid "^3.1.0"
+
+"@storybook/addon-knobs@3.3.15":
+  version "3.3.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.3.15.tgz#b18b067900682deef314785db99dee90a84a8f97"
+  dependencies:
+    babel-runtime "^6.26.0"
+    deep-equal "^1.0.1"
+    global "^4.3.2"
+    insert-css "^2.0.0"
+    lodash.debounce "^4.0.8"
+    moment "^2.20.1"
+    prop-types "^15.6.0"
+    react-color "^2.11.4"
+    react-datetime "^2.11.1"
+    react-textarea-autosize "^5.2.1"
+    util-deprecate "^1.0.2"
+
+"@storybook/addons@3.3.15":
+  version "3.3.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.3.15.tgz#564c5c7a8759b56fc566c4d1e983856bf8994a85"
+
+"@times-components/ad@0.16.11":
+  version "0.16.11"
+  resolved "https://registry.yarnpkg.com/@times-components/ad/-/ad-0.16.11.tgz#f973dc9179b06f89aa83ca58dac25459fb835909"
+  dependencies:
+    "@times-components/styleguide" "0.5.6"
+    "@times-components/watermark" "0.4.16"
+    prop-types "15.6.0"
+    react-broadcast "0.5.2"
+
 "@times-components/ad@0.16.8":
   version "0.16.8"
   resolved "https://registry.yarnpkg.com/@times-components/ad/-/ad-0.16.8.tgz#284ee20fa7b34d5670540ead1220baec58b3da26"
@@ -20,24 +60,33 @@
     "@times-components/styleguide" "0.5.4"
     prop-types "15.6.0"
 
-"@times-components/article-flag@0.11.14":
-  version "0.11.14"
-  resolved "https://registry.yarnpkg.com/@times-components/article-flag/-/article-flag-0.11.14.tgz#547d15ee17cb130e2fdf671934e13e844bad6928"
+"@times-components/article-byline@0.14.8":
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/@times-components/article-byline/-/article-byline-0.14.8.tgz#b8e1702083e6e1ba8e70fef2fc0c904c99da7ebc"
   dependencies:
-    "@times-components/icons" "0.3.14"
-    "@times-components/styleguide" "0.5.4"
+    "@times-components/link" "0.15.17"
+    "@times-components/markup" "0.25.11"
+    "@times-components/styleguide" "0.5.6"
+    prop-types "15.6.0"
+
+"@times-components/article-flag@0.11.17":
+  version "0.11.17"
+  resolved "https://registry.yarnpkg.com/@times-components/article-flag/-/article-flag-0.11.17.tgz#d7cf6ac66e073124096dee6dfa9c1c5cc7593de9"
+  dependencies:
+    "@times-components/icons" "0.3.17"
+    "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
     react-native-svg "5.5.1"
     svgs "3.2.1"
 
-"@times-components/article-image@0.13.5":
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/@times-components/article-image/-/article-image-0.13.5.tgz#d58a514177a88605a0944a8df82974ac45419564"
+"@times-components/article-image@0.13.10":
+  version "0.13.10"
+  resolved "https://registry.yarnpkg.com/@times-components/article-image/-/article-image-0.13.10.tgz#96f39016215a5364941b7abc25675ded5ece4d70"
   dependencies:
-    "@times-components/caption" "0.11.5"
-    "@times-components/image" "1.15.3"
-    "@times-components/responsive-styles" "0.6.0"
-    "@times-components/styleguide" "0.5.4"
+    "@times-components/caption" "0.11.10"
+    "@times-components/image" "1.15.8"
+    "@times-components/responsive-styles" "0.6.2"
+    "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
 
 "@times-components/article-label@0.9.5":
@@ -45,6 +94,14 @@
   resolved "https://registry.yarnpkg.com/@times-components/article-label/-/article-label-0.9.5.tgz#cc6cc125d3d83843700d3ab696c56ceb7cf1240d"
   dependencies:
     "@times-components/styleguide" "0.5.4"
+    lodash.invert "4.3.0"
+    prop-types "15.6.0"
+
+"@times-components/article-label@0.9.8":
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/@times-components/article-label/-/article-label-0.9.8.tgz#c30424c6745b07f95bed196b5b624557833498a7"
+  dependencies:
+    "@times-components/styleguide" "0.5.6"
     lodash.invert "4.3.0"
     prop-types "15.6.0"
 
@@ -62,31 +119,47 @@
     date-fns "1.28.5"
     prop-types "15.6.0"
 
-"@times-components/article@0.62.2":
-  version "0.62.2"
-  resolved "https://registry.yarnpkg.com/@times-components/article/-/article-0.62.2.tgz#fe90ce5328aa198b7b2df9f6080ece44becc2dca"
+"@times-components/article-summary@0.22.4":
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/@times-components/article-summary/-/article-summary-0.22.4.tgz#736324a98aa3ea0bfffa1cf645adf802f0f143d1"
   dependencies:
-    "@times-components/ad" "0.16.8"
-    "@times-components/article-byline" "0.14.5"
-    "@times-components/article-flag" "0.11.14"
-    "@times-components/article-image" "0.13.5"
-    "@times-components/article-label" "0.9.5"
-    "@times-components/article-summary" "0.22.1"
-    "@times-components/brightcove-video" "2.1.2"
-    "@times-components/caption" "0.11.5"
-    "@times-components/card" "0.25.1"
-    "@times-components/date-publication" "0.14.1"
-    "@times-components/image" "1.15.3"
-    "@times-components/link" "0.15.14"
-    "@times-components/markup" "0.25.8"
-    "@times-components/provider" "0.26.0"
-    "@times-components/pull-quote" "0.4.4"
-    "@times-components/responsive-styles" "0.6.0"
-    "@times-components/slice" "0.17.0"
-    "@times-components/styleguide" "0.5.4"
-    "@times-components/topics" "0.2.4"
-    "@times-components/tracking" "0.10.2"
-    "@times-components/video-label" "0.1.18"
+    "@times-components/article-byline" "0.14.8"
+    "@times-components/article-label" "0.9.8"
+    "@times-components/date-publication" "0.14.4"
+    "@times-components/jest-configurator" "0.2.4"
+    "@times-components/markup" "0.25.11"
+    "@times-components/responsive-styles" "0.6.2"
+    "@times-components/styleguide" "0.5.6"
+    date-fns "1.28.5"
+    prop-types "15.6.0"
+
+"@times-components/article@0.62.13":
+  version "0.62.13"
+  resolved "https://registry.yarnpkg.com/@times-components/article/-/article-0.62.13.tgz#e05f779ae8ebc04d2cea37b0598776d2781fe2be"
+  dependencies:
+    "@storybook/addon-knobs" "3.3.15"
+    "@times-components/ad" "0.16.11"
+    "@times-components/article-byline" "0.14.8"
+    "@times-components/article-flag" "0.11.17"
+    "@times-components/article-image" "0.13.10"
+    "@times-components/article-label" "0.9.8"
+    "@times-components/article-summary" "0.22.4"
+    "@times-components/brightcove-video" "2.1.6"
+    "@times-components/caption" "0.11.10"
+    "@times-components/card" "0.25.6"
+    "@times-components/date-publication" "0.14.4"
+    "@times-components/image" "1.15.8"
+    "@times-components/link" "0.15.17"
+    "@times-components/markup" "0.25.11"
+    "@times-components/provider" "0.26.4"
+    "@times-components/pull-quote" "0.4.7"
+    "@times-components/responsive-styles" "0.6.2"
+    "@times-components/slice" "0.17.3"
+    "@times-components/storybook" "0.4.7"
+    "@times-components/styleguide" "0.5.6"
+    "@times-components/topics" "0.2.7"
+    "@times-components/tracking" "0.10.5"
+    "@times-components/video-label" "0.1.21"
     lodash.get "4.4.2"
     prop-types "15.6.0"
 
@@ -126,20 +199,20 @@
     lodash.merge "4.6.0"
     prop-types "15.6.0"
 
-"@times-components/brightcove-video@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@times-components/brightcove-video/-/brightcove-video-2.1.2.tgz#0d088e6c15cc1e833d2fb34f7acb9c9dff65d7de"
+"@times-components/brightcove-video@2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@times-components/brightcove-video/-/brightcove-video-2.1.6.tgz#5e27910ef3401f20d14412955293806e2942bdec"
   dependencies:
-    "@times-components/styleguide" "0.5.4"
+    "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
     react-native-svg "5.5.1"
     svgs "3.2.1"
 
-"@times-components/caption@0.11.5":
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/@times-components/caption/-/caption-0.11.5.tgz#cebbfd7c748790cbcf4e290dc412acac27cd140d"
+"@times-components/caption@0.11.10":
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/@times-components/caption/-/caption-0.11.10.tgz#2c99d60e8596a827b4229da0ba3e7ebeb5d274ba"
   dependencies:
-    "@times-components/styleguide" "0.5.4"
+    "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
 
 "@times-components/card@0.25.1":
@@ -154,6 +227,18 @@
     react-native-svg "5.5.1"
     svgs "3.2.1"
 
+"@times-components/card@0.25.6":
+  version "0.25.6"
+  resolved "https://registry.yarnpkg.com/@times-components/card/-/card-0.25.6.tgz#cce8fb9669e4fc9760616a6caf9a8543a63e4b06"
+  dependencies:
+    "@times-components/gradient" "0.8.6"
+    "@times-components/image" "1.15.8"
+    "@times-components/responsive-styles" "0.6.2"
+    "@times-components/styleguide" "0.5.6"
+    prop-types "15.6.0"
+    react-native-svg "5.5.1"
+    svgs "3.2.1"
+
 "@times-components/date-publication@0.14.1":
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/@times-components/date-publication/-/date-publication-0.14.1.tgz#71430547e638fc18ab0699b16d82d654397c9099"
@@ -161,6 +246,17 @@
     "@times-components/jest-configurator" "0.2.2"
     "@times-components/styleguide" "0.5.4"
     "@times-components/utils" "0.6.0"
+    date-fns "1.28.5"
+    prop-types "15.6.0"
+    react-native-device-info "0.13.0"
+
+"@times-components/date-publication@0.14.4":
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/@times-components/date-publication/-/date-publication-0.14.4.tgz#2c6d24e7fca5d9986896d9e5322c2c996fa2a9fa"
+  dependencies:
+    "@times-components/jest-configurator" "0.2.4"
+    "@times-components/styleguide" "0.5.6"
+    "@times-components/utils" "0.6.3"
     date-fns "1.28.5"
     prop-types "15.6.0"
     react-native-device-info "0.13.0"
@@ -192,6 +288,13 @@
     "@times-components/styleguide" "0.5.4"
     prop-types "15.6.0"
 
+"@times-components/gestures@1.2.26":
+  version "1.2.26"
+  resolved "https://registry.yarnpkg.com/@times-components/gestures/-/gestures-1.2.26.tgz#443d678f24955ead012b5bd25a655411725c895c"
+  dependencies:
+    "@times-components/styleguide" "0.5.6"
+    prop-types "15.6.0"
+
 "@times-components/gradient@0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@times-components/gradient/-/gradient-0.8.2.tgz#314f8672f66acd4e29ef5b6125cb37383a31ce9a"
@@ -201,11 +304,28 @@
     prop-types "15.6.0"
     react-native-linear-gradient "2.4.0"
 
+"@times-components/gradient@0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@times-components/gradient/-/gradient-0.8.6.tgz#6ae54b658344fdaceca08aa14b81497c7502dd62"
+  dependencies:
+    "@times-components/jest-configurator" "0.2.4"
+    "@times-components/styleguide" "0.5.6"
+    prop-types "15.6.0"
+    react-native-linear-gradient "2.4.0"
+
 "@times-components/icons@0.3.14":
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/@times-components/icons/-/icons-0.3.14.tgz#345f1335bdb700b020d1185ee95ce9c14e8935f2"
   dependencies:
     "@times-components/styleguide" "0.5.4"
+    prop-types "15.6.0"
+    svgs "3.2.1"
+
+"@times-components/icons@0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@times-components/icons/-/icons-0.3.17.tgz#25b2c098679b2a146f22a6092b0f7ad136094954"
+  dependencies:
+    "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
     svgs "3.2.1"
 
@@ -221,9 +341,32 @@
     react-native-svg "5.5.1"
     svgs "3.2.1"
 
+"@times-components/image@1.15.8":
+  version "1.15.8"
+  resolved "https://registry.yarnpkg.com/@times-components/image/-/image-1.15.8.tgz#19a1e4e45d08ed48140529e316da8b21461b71e1"
+  dependencies:
+    "@times-components/gestures" "1.2.26"
+    "@times-components/gradient" "0.8.6"
+    "@times-components/link" "0.15.17"
+    "@times-components/styleguide" "0.5.6"
+    prop-types "15.6.0"
+    react-native-svg "5.5.1"
+    svgs "3.2.1"
+
 "@times-components/jest-configurator@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@times-components/jest-configurator/-/jest-configurator-0.2.2.tgz#7a3c76fd5b91a8fdd31fd8d1fe65e6cfada0df8c"
+  dependencies:
+    enzyme "3.3.0"
+    enzyme-adapter-react-16 "1.1.0"
+    enzyme-to-json "3.3.0"
+    find-node-modules "1.0.4"
+    jest-plugin-context "2.6.0"
+    recursive-readdir-synchronous "0.0.3"
+
+"@times-components/jest-configurator@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@times-components/jest-configurator/-/jest-configurator-0.2.4.tgz#476f47d3450bb78ed387c531ee5a62346055dfb5"
   dependencies:
     enzyme "3.3.0"
     enzyme-adapter-react-16 "1.1.0"
@@ -239,6 +382,24 @@
     "@times-components/responsive-styles" "0.6.0"
     "@times-components/styleguide" "0.5.4"
     lodash.pick "4.4.0"
+    prop-types "15.6.0"
+
+"@times-components/link@0.15.17":
+  version "0.15.17"
+  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-0.15.17.tgz#e71b4a6303b62aa9ccdaa8dc61bc2891c636edec"
+  dependencies:
+    "@times-components/responsive-styles" "0.6.2"
+    "@times-components/styleguide" "0.5.6"
+    lodash.pick "4.4.0"
+    prop-types "15.6.0"
+
+"@times-components/markup@0.25.11":
+  version "0.25.11"
+  resolved "https://registry.yarnpkg.com/@times-components/markup/-/markup-0.25.11.tgz#c24908632dc4486827dba1715daceea840dd5ac8"
+  dependencies:
+    "@times-components/ad" "0.16.11"
+    "@times-components/pull-quote" "0.4.7"
+    "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
 
 "@times-components/markup@0.25.8":
@@ -276,6 +437,20 @@
     react-apollo "2.1.0-rc.3"
     react-display-name "0.2.3"
 
+"@times-components/provider@0.26.4":
+  version "0.26.4"
+  resolved "https://registry.yarnpkg.com/@times-components/provider/-/provider-0.26.4.tgz#f9b0dd5a011a36b7765e2dc0f26d370b3de4ef2b"
+  dependencies:
+    apollo-utilities "1.0.4"
+    graphql-tag "2.6.0"
+    hoist-non-react-statics "2.3.1"
+    lodash.get "4.4.2"
+    lodash.isequal "4.4.0"
+    lodash.pick "4.4.0"
+    prop-types "15.6.0"
+    react-apollo "2.1.0-rc.3"
+    react-display-name "0.2.3"
+
 "@times-components/pull-quote@0.4.4":
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/@times-components/pull-quote/-/pull-quote-0.4.4.tgz#a46cb370c234aed3da2912a98f29f34d4362679f"
@@ -285,6 +460,15 @@
     "@times-components/styleguide" "0.5.4"
     prop-types "15.6.0"
 
+"@times-components/pull-quote@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@times-components/pull-quote/-/pull-quote-0.4.7.tgz#d1433c7efd9b61a581c7dc453037bca76cf9a430"
+  dependencies:
+    "@times-components/icons" "0.3.17"
+    "@times-components/link" "0.15.17"
+    "@times-components/styleguide" "0.5.6"
+    prop-types "15.6.0"
+
 "@times-components/responsive-styles@0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@times-components/responsive-styles/-/responsive-styles-0.6.0.tgz#955c7542bb65053449b84f3ac59f96fb63833a60"
@@ -292,13 +476,45 @@
     prop-types "15.6.0"
     styled-components "3.2.2"
 
-"@times-components/slice@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@times-components/slice/-/slice-0.17.0.tgz#9cbcfecf95e9f06da5c2e8bdbd357dab605ed4be"
+"@times-components/responsive-styles@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@times-components/responsive-styles/-/responsive-styles-0.6.2.tgz#ff528082aeb6435bae7b5a436c0f48a0f9220f1b"
   dependencies:
-    "@times-components/responsive-styles" "0.6.0"
-    "@times-components/styleguide" "0.5.4"
     prop-types "15.6.0"
+    styled-components "3.2.2"
+
+"@times-components/slice@0.17.3":
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/@times-components/slice/-/slice-0.17.3.tgz#0f719ce6ff2ae3a9db0174284a621fe592e8a10e"
+  dependencies:
+    "@times-components/responsive-styles" "0.6.2"
+    "@times-components/styleguide" "0.5.6"
+    prop-types "15.6.0"
+
+"@times-components/storybook@0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@times-components/storybook/-/storybook-0.4.7.tgz#35e454bb6c2cac436e3689918dd5e53b29baaa32"
+  dependencies:
+    "@storybook/addon-actions" "3.3.15"
+    "@storybook/addon-knobs" "3.3.15"
+    "@storybook/addons" "3.3.15"
+    "@times-components/jest-configurator" "0.2.4"
+    "@times-components/utils" "0.6.3"
+    apollo-cache-inmemory "1.1.5"
+    apollo-client "2.2.3"
+    apollo-link-http "1.5.2"
+    eslint "4.9.0"
+    eslint-config-airbnb "16.1.0"
+    eslint-config-prettier "2.6.0"
+    eslint-plugin-import "2.8.0"
+    eslint-plugin-jsx-a11y "6.0.2"
+    eslint-plugin-react "7.4.0"
+    prop-types "15.6.0"
+    react "16.2.0"
+    react-apollo "2.1.0-rc.3"
+    react-dom "16.2.0"
+    react-native "0.53.3"
+    react-test-renderer "16.2.0"
 
 "@times-components/styleguide@0.5.4":
   version "0.5.4"
@@ -307,12 +523,19 @@
     "@times-components/responsive-styles" "0.6.0"
     prop-types "15.6.0"
 
-"@times-components/topics@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@times-components/topics/-/topics-0.2.4.tgz#c21f3be88f4faa4876f3420f12267410ddf863ce"
+"@times-components/styleguide@0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@times-components/styleguide/-/styleguide-0.5.6.tgz#c16a322cfbe128bb50807c8cba7ea77391820445"
   dependencies:
-    "@times-components/link" "0.15.14"
-    "@times-components/styleguide" "0.5.4"
+    "@times-components/responsive-styles" "0.6.2"
+    prop-types "15.6.0"
+
+"@times-components/topics@0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@times-components/topics/-/topics-0.2.7.tgz#1f0f12f855ec8c5cbb85a363072ed64ccc3fcee7"
+  dependencies:
+    "@times-components/link" "0.15.17"
+    "@times-components/styleguide" "0.5.6"
     enzyme "3.3.0"
     lodash.orderby "4.6.0"
     prop-types "15.6.0"
@@ -320,6 +543,15 @@
 "@times-components/tracking@0.10.2":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@times-components/tracking/-/tracking-0.10.2.tgz#8ba56f2b593c8a8672bab728104831cf0a0c4228"
+  dependencies:
+    hoist-non-react-statics "2.3.1"
+    lodash.get "4.4.2"
+    prop-types "15.6.0"
+    react-display-name "0.2.3"
+
+"@times-components/tracking@0.10.5":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@times-components/tracking/-/tracking-0.10.5.tgz#57686bff21849db3799af4ca1dacbbfdd574e760"
   dependencies:
     hoist-non-react-statics "2.3.1"
     lodash.get "4.4.2"
@@ -337,12 +569,23 @@
     react "16.2.0"
     react-apollo "2.1.0-rc.3"
 
-"@times-components/video-label@0.1.18":
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/@times-components/video-label/-/video-label-0.1.18.tgz#7fca8af84d71d1252551beb528457d7ea95f1df7"
+"@times-components/utils@0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@times-components/utils/-/utils-0.6.3.tgz#40326254c8875fe7c5ecc7044e6f3c86efbec9f0"
   dependencies:
-    "@times-components/icons" "0.3.14"
-    "@times-components/styleguide" "0.5.4"
+    apollo-cache-inmemory "1.1.5"
+    apollo-client "2.2.3"
+    graphql "0.12.3"
+    prop-types "15.6.0"
+    react "16.2.0"
+    react-apollo "2.1.0-rc.3"
+
+"@times-components/video-label@0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@times-components/video-label/-/video-label-0.1.21.tgz#f49ea28ea694a6e47eb1020276b2dbbb7348f342"
+  dependencies:
+    "@times-components/icons" "0.3.17"
+    "@times-components/styleguide" "0.5.6"
     lodash.invert "4.3.0"
     prop-types "15.6.0"
 
@@ -351,6 +594,15 @@
   resolved "https://registry.yarnpkg.com/@times-components/watermark/-/watermark-0.4.14.tgz#af1b20e4a50ccf1126be883ea96451df858921c0"
   dependencies:
     "@times-components/styleguide" "0.5.4"
+    prop-types "15.6.0"
+    react-native-svg "5.5.1"
+    svgs "3.2.1"
+
+"@times-components/watermark@0.4.16":
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/@times-components/watermark/-/watermark-0.4.16.tgz#59ace947b7f6de9cae849be161f11d20443d54b5"
+  dependencies:
+    "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
     react-native-svg "5.5.1"
     svgs "3.2.1"
@@ -396,9 +648,27 @@ accepts@~1.3.0:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.5.0:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
+
+ajv-keywords@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -407,7 +677,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
+ajv@^5.1.0, ajv@^5.2.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -415,6 +685,15 @@ ajv@^5.1.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.0.1:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.4.0.tgz#d3aff78e9277549771daf0164cff48482b754fc6"
+  dependencies:
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+    uri-js "^3.0.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -537,6 +816,10 @@ apollo-link@^1.0.0, apollo-link@^1.2.1:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.6"
 
+apollo-utilities@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.4.tgz#560009ea5541b9fdc4ee07ebb1714ee319a76c15"
+
 apollo-utilities@^1.0.0, apollo-utilities@^1.0.11, apollo-utilities@^1.0.4, apollo-utilities@^1.0.6:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.11.tgz#cd36bfa6e5c04eea2caf0c204a0f38a0ad550802"
@@ -555,6 +838,19 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
+aria-query@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.1.tgz#26cbb5aff64144b0a825be1846e0b16cfa00b11e"
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -590,6 +886,13 @@ array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
 
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
+
 array-map@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
@@ -616,7 +919,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -643,6 +946,10 @@ assert-plus@^0.2.0:
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -678,6 +985,12 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axobject-query@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
+  dependencies:
+    ast-types-flow "0.0.7"
+
 babel-cli@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
@@ -699,7 +1012,7 @@ babel-cli@6.26.0:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -1660,7 +1973,7 @@ buffer@^5.0.3:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1695,6 +2008,16 @@ cachedir@^1.1.0:
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-1.2.0.tgz#e9a0a25bb21a2b7a0f766f07c41eb7a311919b97"
   dependencies:
     os-homedir "^1.0.1"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -1801,6 +2124,10 @@ chokidar@^1.6.1:
 ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
+
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2059,6 +2386,10 @@ connect@^3.6.5:
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
 content-type@~1.0.1:
   version "1.0.4"
@@ -2350,6 +2681,10 @@ cz-conventional-changelog@1.2.0:
     right-pad "^1.0.1"
     word-wrap "^1.0.3"
 
+damerau-levenshtein@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+
 dargs@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
@@ -2374,9 +2709,15 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
@@ -2409,9 +2750,17 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
+deep-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -2444,6 +2793,18 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2496,6 +2857,19 @@ detect-newline@^2.1.0:
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -2569,6 +2943,10 @@ ee-first@1.1.1:
 electron-to-chromium@^1.3.30:
   version "1.3.41"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz#7e33643e00cd85edfd17e04194f6d00e73737235"
+
+emoji-regex@^6.1.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
 encodeurl@~1.0.1:
   version "1.0.2"
@@ -2653,7 +3031,7 @@ errorhandler@~1.4.2:
     accepts "~1.3.0"
     escape-html "~1.0.3"
 
-es-abstract@^1.6.1:
+es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
   dependencies:
@@ -2682,6 +3060,154 @@ escape-html@~1.0.3:
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
+
+eslint-config-airbnb@16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz#2546bfb02cc9fe92284bf1723ccf2e87bc45ca46"
+  dependencies:
+    eslint-config-airbnb-base "^12.1.0"
+
+eslint-config-prettier@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz#f21db0ebb438ad678fb98946097c4bb198befccc"
+  dependencies:
+    get-stdin "^5.0.1"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+
+eslint-plugin-jsx-a11y@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz#659277a758b036c305a7e4a13057c301cd3be73f"
+  dependencies:
+    aria-query "^0.7.0"
+    array-includes "^3.0.3"
+    ast-types-flow "0.0.7"
+    axobject-query "^0.1.0"
+    damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^1.4.0"
+
+eslint-plugin-react@7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz#300a95861b9729c087d362dd64abcc351a74364a"
+  dependencies:
+    doctrine "^2.0.0"
+    has "^1.0.1"
+    jsx-ast-utils "^2.0.0"
+    prop-types "^15.5.10"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.9.0.tgz#76879d274068261b191fe0f2f56c74c2f4208e8b"
+  dependencies:
+    ajv "^5.2.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.0.1"
+    doctrine "^2.0.0"
+    eslint-scope "^3.7.1"
+    espree "^3.5.1"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^9.17.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "^4.0.1"
+    text-table "~0.2.0"
+
+espree@^3.5.1:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esquery@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -2853,6 +3379,10 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
 fb-watchman@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
@@ -2896,6 +3426,13 @@ figures@^2.0.0:
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -2973,6 +3510,15 @@ findup-sync@0.4.2:
     is-glob "^2.0.1"
     micromatch "^2.3.7"
     resolve-dir "^0.1.0"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 flow-bin@0.63.1:
   version "0.63.1"
@@ -3094,6 +3640,10 @@ function.prototype.name@^1.0.3:
     function-bind "^1.1.1"
     is-callable "^1.1.3"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
 gauge@~1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-1.2.7.tgz#e9cec5483d3d4ee0ef44b60a7d99e4935e136d93"
@@ -3138,6 +3688,10 @@ get-port@^3.2.0:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -3241,16 +3795,27 @@ global-prefix@^0.1.4:
     is-windows "^0.2.0"
     which "^1.2.12"
 
-global@^4.3.0:
+global@^4.3.0, global@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^9.18.0:
+globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globby@^6.1.0:
   version "6.1.0"
@@ -3535,6 +4100,10 @@ ieee754@^1.1.4:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
 
+ignore@^3.3.3:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
 image-size@^0.6.0:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.2.tgz#8ee316d4298b028b965091b673d5f1537adee5b4"
@@ -3623,6 +4192,10 @@ inquirer@^3.0.6, inquirer@^3.2.2:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
 
 interpret@^1.0.0:
   version "1.1.0"
@@ -3716,6 +4289,10 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-dom@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.0.9.tgz#483832d52972073de12b9fe3f60320870da8370d"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -3802,6 +4379,22 @@ is-odd@^2.0.0:
   dependencies:
     is-number "^4.0.0"
 
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
@@ -3833,6 +4426,10 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-resolvable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
@@ -3880,7 +4477,7 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -3956,6 +4553,13 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-yaml@^3.9.1:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -4026,6 +4630,16 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsx-ast-utils@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+
+jsx-ast-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
+  dependencies:
+    array-includes "^3.0.3"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4111,6 +4725,13 @@ lerna@2.8.0:
     write-pkg "^3.1.0"
     yargs "^8.0.2"
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -4181,6 +4802,14 @@ lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
 lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
+
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
 lodash.escape@^3.0.0:
   version "3.2.0"
@@ -4294,7 +4923,7 @@ lodash@4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
-lodash@4.17.5, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.5, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -4344,6 +4973,10 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-error@^1.3.2:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -4367,6 +5000,10 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+material-colors@^1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.5.tgz#5292593e6754cb1bcc2b98030e4e0d6a3afc9ea1"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -4573,7 +5210,7 @@ minimatch@0.3.0:
     lru-cache "2"
     sigmund "~1.0.0"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -4619,7 +5256,7 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
 
-moment@^2.6.0:
+moment@^2.20.1, moment@^2.6.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
@@ -4686,6 +5323,10 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 nearley@^2.7.10:
   version "2.13.0"
@@ -4944,6 +5585,17 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
 options@>=0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
@@ -5087,6 +5739,10 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
 path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -5149,6 +5805,12 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
 plist@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
@@ -5166,6 +5828,10 @@ plist@^1.2.0:
     xmlbuilder "4.0.0"
     xmldom "0.1.x"
 
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -5173,6 +5839,10 @@ posix-character-classes@^0.1.0:
 postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
 prepend-http@^1.0.1:
   version "1.0.4"
@@ -5202,6 +5872,10 @@ process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
 
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -5216,7 +5890,7 @@ prop-types@15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -5231,6 +5905,10 @@ pseudomap@^1.0.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 q@^1.4.1, q@^1.5.1:
   version "1.5.1"
@@ -5322,6 +6000,25 @@ react-clone-referenced-element@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz#2bba8c69404c5e4a944398600bcc4c941f860682"
 
+react-color@^2.11.4:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.14.0.tgz#5828a11c034aa0939befbd888a066ee37d8c3cc2"
+  dependencies:
+    lodash "^4.0.1"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
+
+react-datetime@^2.11.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.14.0.tgz#c7859c5b765275d7980f1cca27c03a727ff9ccef"
+  dependencies:
+    create-react-class "^15.5.2"
+    object-assign "^3.0.0"
+    prop-types "^15.5.7"
+    react-onclickoutside "^6.5.0"
+
 react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
@@ -5336,6 +6033,22 @@ react-devtools-core@3.0.0:
 react-display-name@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.3.tgz#f50204d430c9ca819bc0bade0306e9175d8d1987"
+
+react-dom@16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-inspector@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
+  dependencies:
+    babel-runtime "^6.26.0"
+    is-dom "^1.0.9"
 
 react-is@^16.3.0:
   version "16.3.0"
@@ -5417,12 +6130,24 @@ react-native@0.53.3:
     xmldoc "^0.4.0"
     yargs "^9.0.0"
 
+react-onclickoutside@^6.5.0:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
 react-proxy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-1.1.8.tgz#9dbfd9d927528c3aa9f444e4558c37830ab8c26a"
   dependencies:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
+
+react-test-renderer@16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-test-renderer@^16.0.0-0:
   version "16.3.0"
@@ -5432,6 +6157,12 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
     react-is "^16.3.0"
+
+react-textarea-autosize@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz#2b78f9067180f41b08ac59f78f1581abadd61e54"
+  dependencies:
+    prop-types "^15.6.0"
 
 react-timer-mixin@^0.13.2:
   version "0.13.3"
@@ -5452,6 +6183,12 @@ react@16.2.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+reactcss@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
+  dependencies:
+    lodash "^4.0.1"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -5708,6 +6445,13 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
@@ -5715,11 +6459,15 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.6:
+resolve@^1.1.6, resolve@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.6.0.tgz#0fbd21278b27b4004481c395349e7aba60a9ff5c"
   dependencies:
@@ -5760,7 +6508,7 @@ right-pad@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -5972,6 +6720,12 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
@@ -6106,6 +6860,10 @@ split@^1.0.0:
   dependencies:
     through "2"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
 sshpk@^1.7.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
@@ -6161,7 +6919,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -6282,6 +7040,17 @@ symbol-observable@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
+table@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
+  dependencies:
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -6336,6 +7105,10 @@ text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
 
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
 throat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -6358,6 +7131,10 @@ time-stamp@^1.0.0:
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
+tinycolor2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
 
 tmp@^0.0.29:
   version "0.0.29"
@@ -6436,6 +7213,12 @@ tunnel-agent@^0.6.0:
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-is@~1.6.6:
   version "1.6.16"
@@ -6528,6 +7311,12 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
+uri-js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-3.0.2.tgz#f90b858507f81dea4dcfbb3c4c3dbfa2b557faaa"
+  dependencies:
+    punycode "^2.1.0"
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -6548,7 +7337,7 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
-util-deprecate@1.0.2, util-deprecate@~1.0.1:
+util-deprecate@1.0.2, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
@@ -6674,7 +7463,7 @@ wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
 
-wordwrap@^1.0.0:
+wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
@@ -6726,6 +7515,12 @@ write-pkg@^3.1.0:
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^1.1.0:
   version "1.1.5"


### PR DESCRIPTION
We need the play icon on the lead asset video button, which has been done in https://github.com/newsuk/times-components/pull/809

This bumps the dependency version so we'll be able to use that.

Another change we need is in `@times-components/provider`, so that we'll be able to query for brightcove data.