### PR TITLE
Bump article version to latest

### DIFF
--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@thetimes/with-client": "1.0.7",
-    "@times-components/article": "0.62.13",
+    "@times-components/article": "0.62.15",
     "@times-components/provider": "0.26.4",
     "react": "16.2.0",
     "react-native": "0.53.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,9 +133,9 @@
     date-fns "1.28.5"
     prop-types "15.6.0"
 
-"@times-components/article@0.62.13":
-  version "0.62.13"
-  resolved "https://registry.yarnpkg.com/@times-components/article/-/article-0.62.13.tgz#e05f779ae8ebc04d2cea37b0598776d2781fe2be"
+"@times-components/article@0.62.15":
+  version "0.62.15"
+  resolved "https://registry.yarnpkg.com/@times-components/article/-/article-0.62.15.tgz#e30220239034f455afec8a03739de3aa53cc714b"
   dependencies:
     "@storybook/addon-knobs" "3.3.15"
     "@times-components/ad" "0.16.11"
@@ -153,8 +153,8 @@
     "@times-components/markup" "0.25.11"
     "@times-components/provider" "0.26.4"
     "@times-components/pull-quote" "0.4.7"
+    "@times-components/related-articles" "0.0.2"
     "@times-components/responsive-styles" "0.6.2"
-    "@times-components/slice" "0.17.3"
     "@times-components/storybook" "0.4.7"
     "@times-components/styleguide" "0.5.6"
     "@times-components/topics" "0.2.7"
@@ -469,6 +469,21 @@
     "@times-components/styleguide" "0.5.6"
     prop-types "15.6.0"
 
+"@times-components/related-articles@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@times-components/related-articles/-/related-articles-0.0.2.tgz#1540afcc5cacdd17cd3b4a0c01e0d49153362286"
+  dependencies:
+    "@times-components/article-summary" "0.22.4"
+    "@times-components/card" "0.25.6"
+    "@times-components/link" "0.15.17"
+    "@times-components/markup" "0.25.11"
+    "@times-components/slice" "0.17.4"
+    "@times-components/styleguide" "0.5.6"
+    "@times-components/tealium" "0.2.15"
+    "@times-components/tracking" "0.10.5"
+    lodash.get "4.4.2"
+    prop-types "15.6.0"
+
 "@times-components/responsive-styles@0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@times-components/responsive-styles/-/responsive-styles-0.6.0.tgz#955c7542bb65053449b84f3ac59f96fb63833a60"
@@ -483,9 +498,9 @@
     prop-types "15.6.0"
     styled-components "3.2.2"
 
-"@times-components/slice@0.17.3":
-  version "0.17.3"
-  resolved "https://registry.yarnpkg.com/@times-components/slice/-/slice-0.17.3.tgz#0f719ce6ff2ae3a9db0174284a621fe592e8a10e"
+"@times-components/slice@0.17.4":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@times-components/slice/-/slice-0.17.4.tgz#adfe807ba84dbec2aaa7f9412f6be9f12e60c756"
   dependencies:
     "@times-components/responsive-styles" "0.6.2"
     "@times-components/styleguide" "0.5.6"
@@ -529,6 +544,13 @@
   dependencies:
     "@times-components/responsive-styles" "0.6.2"
     prop-types "15.6.0"
+
+"@times-components/tealium@0.2.15":
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@times-components/tealium/-/tealium-0.2.15.tgz#4925e2fc028edf106e4acbc82cfefb0c86ac5185"
+  dependencies:
+    "@storybook/addon-actions" "3.3.15"
+    "@storybook/addons" "3.3.15"
 
 "@times-components/topics@0.2.7":
   version "0.2.7"


### PR DESCRIPTION
The last time we bumped, there was a bug on the article component. This incorporates https://github.com/newsuk/times-components/pull/818